### PR TITLE
Update End to expose io.Reader/Writer

### DIFF
--- a/end.go
+++ b/end.go
@@ -8,8 +8,8 @@ import (
 
 // End is one 'end' of a simulated connection.
 type End struct {
-	Reader *io.PipeReader
-	Writer *io.PipeWriter
+	Reader *io.Reader
+	Writer *io.Writer
 }
 
 func (c End) Close() error {


### PR DESCRIPTION
This allows users to wrap the mock connection in iotest readers like the DataErrReader to simulate edge cases.